### PR TITLE
FAQ_Feedback2

### DIFF
--- a/src/app/page/bottom/faq/faq.component.css
+++ b/src/app/page/bottom/faq/faq.component.css
@@ -41,7 +41,8 @@
 
 .answer {
     border-top: 0px;
-    height: 100px;
+    min-height: 100px;
+    white-space: pre-wrap;
 }
 
 .fas {

--- a/src/app/page/bottom/faq/faq.component.ts
+++ b/src/app/page/bottom/faq/faq.component.ts
@@ -21,7 +21,7 @@ export class FaqComponent implements OnInit {
     private modal: NzModalService,
     private message: NzMessageService) {
     this.faqs.pageNumber = 1;
-    this.faqs.size = 10;
+    this.faqs.size = 15;
     this.getFaqs();
   }
 


### PR DESCRIPTION
[ FAQ 페이지 Feedback2 ]

- faq.component.css (.answer 최소 높이 지정 및 줄바꿈 처리)
- faq.component.ts (화면 내 FAQ 갯수 조정)

> 문제점 <
FAQ 리스트들이 page.component.html 하단의 bottom 항목과 겹침 현상이 있습니다.
이를 해결하기 위해, float: left로 인한 div 인식 불가 문제를 예상했으나 해결되지 않았습니다.
faq.component.html의 faq div 항목과 page.component.html의 bottom div 항목 간, 유기적인 공간 배분의 방법이 있는지 궁금합니다.